### PR TITLE
Fix IntEnum tutorial removing no_docstring argument

### DIFF
--- a/doc/development/tutorials/examples/autodoc_intenum.py
+++ b/doc/development/tutorials/examples/autodoc_intenum.py
@@ -33,10 +33,9 @@ class IntEnumDocumenter(ClassDocumenter):
 
     def add_content(self,
                     more_content: StringList | None,
-                    no_docstring: bool = False,
                     ) -> None:
 
-        super().add_content(more_content, no_docstring)
+        super().add_content(more_content)
 
         source_name = self.get_sourcename()
         enum_object: IntEnum = self.object


### PR DESCRIPTION
The no_docstring argument was deprecated and the parent class is no longer accepting it.

### Feature or Bugfix
- Bugfix

### Purpose
- Just to fix the bug so the tutorial example works out of the box
- Sphinx 7.0.1




